### PR TITLE
Update environment variable for Drift Data API authentication key

### DIFF
--- a/backend/api/market_recommender.py
+++ b/backend/api/market_recommender.py
@@ -329,7 +329,7 @@ def fetch_drift_data_api_data(discovered_markets: Dict = None) -> Dict:
     # Constants for trade fetching
     DAYS_TO_CONSIDER = 30
     DRIFT_DATA_API_BASE = os.getenv("DRIFT_DATA_API_BASE_URL", "https://data.api.drift.trade")
-    DRIFT_DATA_API_AUTH = os.getenv("DRIFT_DATA_API_AUTH", "")  # Get auth token from env
+    DRIFT_DATA_API_AUTH = os.getenv("DRIFT_DATA_API_AUTH_KEY", "")  # Get auth token from env
     DRIFT_DATA_API_HEADERS = {
         "accept": "application/json",
         "x-origin-verify": DRIFT_DATA_API_AUTH  # Use x-origin-verify header


### PR DESCRIPTION
- Changed the environment variable name for the Drift Data API authentication token from `DRIFT_DATA_API_AUTH` to `DRIFT_DATA_API_AUTH_KEY` to match the env var set on infra v3 config for backend container