### PR TITLE
Add Open Interest API and Page Integration

### DIFF
--- a/backend/api/open_interest_api.py
+++ b/backend/api/open_interest_api.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter
+from driftpy.constants.numeric_constants import PRICE_PRECISION
+
+from backend.state import BackendRequest
+
+router = APIRouter()
+
+async def _get_open_interest_per_authority(request: BackendRequest) -> dict:
+    vat = request.state.backend_state.vat
+    slot = request.state.backend_state.last_oracle_slot
+
+    oi_per_authority = {} 
+
+    for user_data in vat.users.values():
+        user_account = user_data.get_user_account()
+        
+        if user_account is None:
+            # Optionally log this: print(f"Warning: Skipping user_data as get_user_account() returned None.")
+            continue
+
+        authority = str(user_account.authority)
+
+        current_oi_for_authority = oi_per_authority.get(authority, {
+            'total_open_interest_usd': 0.0, 
+            'authority': authority
+        })
+
+        for position in user_account.perp_positions:
+            if position.base_asset_amount == 0:
+                continue
+
+            market_index = position.market_index
+            oracle_price_data = vat.perp_oracles.get(market_index)
+            
+            if oracle_price_data is None:
+                print(f"Warning: Missing oracle price data for market_index {market_index} for authority {authority}. Skipping position.")
+                continue
+            
+            try:
+                oracle_price = float(oracle_price_data.price) / PRICE_PRECISION
+                # All perpetual markets use BASE_PRECISION (10^9) for base asset amounts.
+                decimals = 9 
+
+                base_asset_amount_val = position.base_asset_amount
+                if base_asset_amount_val is None: # Should not happen with base_asset_amount == 0 check, but good for safety
+                    print(f"Warning: Position base_asset_amount is None for authority {authority}, market {market_index}. Skipping position.")
+                    continue
+
+                position_value_usd = (abs(base_asset_amount_val) / (10**decimals)) * oracle_price
+                current_oi_for_authority['total_open_interest_usd'] += position_value_usd
+            except (TypeError, ValueError) as e:
+                base_val_repr = repr(getattr(position, 'base_asset_amount', 'N/A'))
+                oracle_price_repr = repr(getattr(oracle_price_data, 'price', 'N/A'))
+                print(f"Error calculating position_value_usd for authority {authority}, market {market_index}: {e}. Base: {base_val_repr}, OraclePriceRaw: {oracle_price_repr}. Skipping position.")
+                continue
+        
+        if current_oi_for_authority['total_open_interest_usd'] > 0:
+             oi_per_authority[authority] = current_oi_for_authority
+    
+    # Filtered values are now implicitly handled by only adding to oi_per_authority if OI > 0
+    result_list = sorted(list(oi_per_authority.values()), key=lambda x: x['total_open_interest_usd'], reverse=True)
+    
+    return {
+        "slot": slot,
+        "data": result_list, 
+    }
+
+@router.get("/per-authority")
+async def get_open_interest_per_authority(request: BackendRequest):
+    return await _get_open_interest_per_authority(request)

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,7 @@ from backend.api import (
     liquidation,
     market_recommender_api,
     metadata,
+    open_interest_api,
     pnl,
     positions,
     price_shock,
@@ -88,6 +89,7 @@ app.include_router(pnl.router, prefix="/api/pnl", tags=["pnl"])
 app.include_router(vaults.router, prefix="/api/vaults", tags=["vaults"])
 app.include_router(positions.router, prefix="/api/positions", tags=["positions"])
 app.include_router(market_recommender_api.router, prefix="/api/market-recommender", tags=["market-recommender"])
+app.include_router(open_interest_api.router, prefix="/api/open-interest", tags=["open-interest"])
 # NOTE: All other routes should be in /api/* within the /api folder. Routes outside of /api are not exposed in k8s
 @app.get("/")
 async def root():

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,7 @@ from page.swap import show as swap_page
 from page.vaults import vaults_page
 from page.welcome import welcome_page
 from page.market_recommender_page import market_recommender_page
+from page.open_interest_page import open_interest_page
 
 load_dotenv()
 
@@ -134,6 +135,12 @@ if __name__ == "__main__":
             url_path="vaults",
             title="Vaults",
             icon="🏦",
+        ),
+        st.Page(
+            open_interest_page,
+            url_path="open-interest",
+            title="Open Interest",
+            icon="💰",
         ),
     ]
 

--- a/src/page/open_interest_page.py
+++ b/src/page/open_interest_page.py
@@ -1,0 +1,66 @@
+import streamlit as st
+import pandas as pd
+from lib.api import fetch_api_data
+from utils import get_current_slot
+
+def open_interest_page():
+    st.title("Open Interest per Authority")
+
+    try:
+        # Fetch data from the API endpoint directly
+        result = fetch_api_data(
+            section="open-interest", 
+            path="per-authority",
+            retry=True # Enable retry for cache misses/processing states
+        )
+        
+        if result is None:
+            st.error("Failed to fetch data from the API.")
+            return
+
+        data = result.get("data", [])
+        slot = result.get("slot", "N/A")
+        current_slot = get_current_slot()
+
+        if slot != "N/A" and current_slot:
+            try:
+                slot_age = int(current_slot) - int(slot)
+                st.info(f"Displaying data for slot {slot} (age: {slot_age} slots)")
+            except ValueError:
+                st.info(f"Displaying data for slot {slot}. Current slot: {current_slot}")
+        else:
+            st.info(f"Slot information unavailable. Current slot: {current_slot}")
+
+        if not data:
+            st.warning("No open interest data found.")
+            return
+
+        df = pd.DataFrame(data)
+
+        if df.empty:
+            st.warning("No open interest data to display.")
+            return
+
+        # Rename columns for better readability
+        df.rename(columns={
+            'authority': 'User Authority',
+            'total_open_interest_usd': 'Total Open Interest (USD)'
+        }, inplace=True)
+        # Reorder columns
+        df = df[["User Authority", "Total Open Interest (USD)"]]
+        # Format USD column with dollar sign and commas
+        df["Total Open Interest (USD)"] = df["Total Open Interest (USD)"].apply(lambda x: f"${x:,.2f}")
+        
+        st.metric("Total Authorities with Open Interest", len(df))
+        st.metric("Total Open Interest (USD)", f"{df['Total Open Interest (USD)'].str.replace('$','').str.replace(',','').astype(float).sum():,.2f}")
+
+        st.subheader("Open Interest Details")
+        st.dataframe(df, hide_index=True)
+
+    except Exception as e:
+        st.error(f"An error occurred while displaying the page: {e}")
+        import traceback
+        st.text(traceback.format_exc())
+
+if __name__ == "__main__":
+    open_interest_page()


### PR DESCRIPTION
- Introduced the Open Interest API by including the `open_interest_api` router in the backend application, making it accessible at the `/api/open-interest` endpoint.
- Updated the Streamlit frontend to include a new page for Open Interest, allowing users to navigate to this section via the URL path `open-interest`, complete with a designated title and icon.
- These changes enhance the application's functionality by providing users with access to Open Interest data, contributing to a more comprehensive trading analysis tool.