### PR TITLE
Add User Retention API and Streamlit Page

### DIFF
--- a/backend/api/user_retention_api.py
+++ b/backend/api/user_retention_api.py
@@ -1,0 +1,423 @@
+# This new API endpoint will implement hype_market_retention.py and return it as a JSON object.
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Tuple, Set, Optional, Any
+
+import pandas as pd
+from dateutil import tz
+from pyathena import connect
+import warnings
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import logging
+
+import boto3
+
+def log_current_identity():
+    try:
+        sts = boto3.client("sts")
+        identity = sts.get_caller_identity()
+        logger.info(f"Running as: {identity}")
+    except Exception as e:
+        logger.warning(f"Could not determine AWS identity: {e}")
+
+# Ignore UserWarning from pyathena/pandas if any
+warnings.filterwarnings("ignore", category=UserWarning)
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ───────────────────────── 1. CONFIG (adapted from hype_market_retention.py) ───────────────────────── #
+
+HYPE_MARKETS: Dict[str, Dict[str, int]] = {
+    "WIF-PERP":   {"index": 23, "launch_ts": 1706219971000},
+    "POPCAT-PERP":{"index": 34, "launch_ts": 1720013054000},
+    "HYPE-PERP":  {"index": 59, "launch_ts": 1733374800000}, # Example, adjust as needed
+    "KAITO-PERP": {"index": 69, "launch_ts": 1739545901000}, # Example, adjust as needed
+    "FARTCOIN-PERP": {"index": 71, "launch_ts": 1743086746000}, # Example, adjust as needed
+    "TRUMP-PERP": {"index": 64, "launch_ts": 1737219250000}, # Example, adjust as needed
+    "LAUNCHCOIN-PERP": {"index": 74, "launch_ts": 1747318237000} # Example, adjust as needed
+}
+
+NEW_TRADER_WINDOW_DAYS: int = 7
+RETENTION_WINDOWS_DAYS: List[int] = [14, 28] # Affects Pydantic model if changed
+CHUNK_DAYS: int = 28
+
+DATABASE = os.environ.get("ATHENA_DATABASE", "mainnet-beta-archive")
+REGION   = os.environ.get("AWS_REGION", "eu-west-1")
+S3_OUTPUT = os.environ.get("ATHENA_S3_OUTPUT", "s3://mainnet-beta-data-ingestion-bucket/athena/")
+
+
+# Derived constant for easier lookup by market index
+# MARKET_CONFIG_BY_INDEX: Dict[int, Dict[str, any]] = {
+# cfg["index"]: {"name": name, **cfg} for name, cfg in HYPE_MARKETS.items()
+# }
+
+# ──────────────────────── 1A. Pydantic Models ──────────────────────── #
+
+class RetentionSummaryItem(BaseModel):
+    market: str
+    new_traders: int
+    new_traders_list: Optional[List[str]] = None
+    retained_users_14d: Optional[int] = None
+    retention_ratio_14d: Optional[float] = None
+    retained_users_14d_list: Optional[List[str]] = None
+    retained_users_28d: Optional[int] = None
+    retention_ratio_28d: Optional[float] = None
+    retained_users_28d_list: Optional[List[str]] = None
+
+    class Config:
+        orm_mode = True # Changed from allow_population_by_field_name for Pydantic v2
+        # For Pydantic v1, it would be:
+        # allow_population_by_field_name = True 
+        # To handle field names like 'retained_users_14d' if data comes with underscores
+
+
+# ──────────────────────── 2. HELPERS (Copied and adapted from hype_market_retention.py) ──────────────────────── #
+
+UTC = tz.tzutc()
+
+def dt_from_ms(ms: int) -> datetime:
+    return datetime.fromtimestamp(ms / 1_000, tz=UTC)
+
+def partition_tuples(start: datetime, days: int) -> Set[Tuple[str, str, str]]:
+    return {
+        (d.strftime("%Y"), d.strftime("%m"), d.strftime("%d"))
+        for d in (start + timedelta(n) for n in range(days))
+    }
+
+def partition_pred(parts: Set[Tuple[str, str, str]]) -> str:
+    lines = [
+        f"(year='{y}' AND month='{m}' AND day='{d}')" for y, m, d in sorted(parts)
+    ]
+    return " OR ".join(lines)
+
+def sql_new_traders(mkt_idx: int, launch_ms: int) -> str:
+    start_dt = dt_from_ms(launch_ms)
+    parts = partition_pred(partition_tuples(start_dt, NEW_TRADER_WINDOW_DAYS))
+    return f"""
+        SELECT "user",
+               MIN(slot) AS first_slot,
+               MIN(ts)   AS first_ts
+        FROM   eventtype_orderrecord
+        WHERE  ({parts})
+          AND  "order".marketindex = {mkt_idx}
+          AND  ("order".orderid = 0 OR "order".orderid = 1)
+        GROUP  BY "user"
+    """
+
+def sql_retention_users_chunk(traders: List[str],
+                               hype_idx: int,
+                               chunk_start: datetime,
+                               chunk_days: int) -> str:
+    chunk_end = chunk_start + timedelta(days=chunk_days)
+    start_ts = int(chunk_start.timestamp())
+    end_ts = int(chunk_end.timestamp())
+    from_date = chunk_start.strftime('%Y%m%d')
+    to_date = chunk_end.strftime('%Y%m%d')
+    trader_list = "', '".join(traders)
+
+    return f'''
+        WITH time_range AS (
+            SELECT 
+                {start_ts} AS from_ts,
+                {end_ts} AS to_ts,
+                '{from_date}' AS from_date,
+                '{to_date}' AS to_date
+        )
+        SELECT DISTINCT "user"
+        FROM   eventtype_orderrecord, time_range
+        WHERE  CAST(ts AS INT) BETWEEN time_range.from_ts AND time_range.to_ts
+          AND  CONCAT(year, month, day) BETWEEN time_range.from_date AND time_range.to_date
+          AND  "order".marketindex <> {hype_idx}
+          AND  "user" IN ('{trader_list}')
+    '''
+
+# ───────────────────── 3. MAIN DATA FETCHING AND PROCESSING LOGIC ───────────────────── #
+
+async def fetch_and_process_retention_data() -> pd.DataFrame:
+    conn = None
+    try:
+        logger.info(f"Connecting to Athena. S3 staging: {S3_OUTPUT}, Region: {REGION}, DB: {DATABASE}")
+        conn = connect(
+            s3_staging_dir=S3_OUTPUT,
+            region_name=REGION,
+            schema_name=DATABASE, # schema_name is used for the default database in queries
+        )
+        logger.info("Successfully connected to Athena.")
+        
+        log_current_identity()
+
+        # 3A. discover "new traders" per market
+        logger.info("Scanning for new traders across all hype markets...")
+        new_traders_frames: List[pd.DataFrame] = []
+        for mkt, cfg in HYPE_MARKETS.items():
+            logger.info(f"• Scanning new traders for {mkt}…")
+            q = sql_new_traders(cfg["index"], cfg["launch_ts"])
+            # logger.debug(f"Generated SQL for {mkt} new traders:\\n{q}")
+            try:
+                df = pd.read_sql(q, conn)
+                df["market"] = mkt
+                new_traders_frames.append(df)
+                logger.info(f"Found {len(df)} new traders for {mkt}.")
+            except Exception as e:
+                logger.error(f"Error fetching new traders for market {mkt}: {e}")
+                # Optionally, append an empty DataFrame or specific error marker
+                # For now, just logs and continues, potentially resulting in empty new_traders for this market
+        
+        if not new_traders_frames:
+            logger.warning("No new traders found for any market.")
+            new_traders = pd.DataFrame(columns=["trader", "first_slot", "first_ts", "market"])
+        else:
+            new_traders = (
+                pd.concat(new_traders_frames, ignore_index=True)
+                  .rename(columns={"user": "trader"})
+            )
+        logger.info(f"Processed a total of {len(new_traders)} new trader records across all markets.")
+
+        # 3AA. Prepare list of new traders per market
+        if not new_traders.empty:
+            new_traders_lists_df = new_traders.groupby('market')['trader'].apply(list).reset_index(name='new_traders_list')
+        else:
+            new_traders_lists_df = pd.DataFrame({'market': pd.Series(dtype='str'), 'new_traders_list': pd.Series(dtype='object')})
+
+        # 3B. retention look-ups
+        retention_records: List[Dict[str, object]] = []
+        if not new_traders.empty:
+            for mkt, cfg in HYPE_MARKETS.items():
+                mkt_traders = new_traders[new_traders.market == mkt].trader.tolist()
+                if not mkt_traders:
+                    logger.info(f"No new traders for market {mkt}, skipping retention lookup.")
+                    continue
+
+                hype_idx = cfg["index"]
+                launch_ms = cfg["launch_ts"]
+                # The original script uses `start_dt = dt_from_ms(launch_ms)` here.
+                # This `start_dt` is the launch time of the hype market.
+                # Retention is checked *from this launch time* up to `win` days.
+                retention_period_start_dt = dt_from_ms(launch_ms) 
+
+                for win in RETENTION_WINDOWS_DAYS:
+                    offset = 0
+                    retained_set: Set[str] = set()
+                    
+                    # The retention window is [launch_ts, launch_ts + win days).
+                    # We query in chunks within this period.
+                    while offset < win : # Iterate through chunks covering the *win* day retention period
+                        # Chunk starts from retention_period_start_dt + offset
+                        chunk_start_dt = retention_period_start_dt + timedelta(days=offset)
+                        # Span is CHUNK_DAYS, but not exceeding the total 'win' days from retention_period_start_dt
+                        # Max days for this chunk from chunk_start_dt: win - offset
+                        span = min(CHUNK_DAYS, win - offset)
+                        
+                        if span <= 0: # Should not happen if while condition is offset < win
+                            break
+
+                        logger.info(f"Fetching retention for {mkt}, window {win}d, chunk: {chunk_start_dt.strftime('%Y-%m-%d')} for {span} days, {len(mkt_traders)} traders")
+                        q_retention_chunk = sql_retention_users_chunk(mkt_traders, hype_idx, chunk_start_dt, span)
+                        # logger.debug(f"Retention SQL for chunk:\n{q_retention_chunk}")
+                        try:
+                            retained_users_df = pd.read_sql(q_retention_chunk, conn)
+                            retained_set.update(retained_users_df["user"].tolist())
+                        except Exception as e: # Catch issues with individual SQL queries
+                             logger.error(f"Error fetching retention chunk for {mkt}, window {win}d, chunk {offset}: {e}")
+                        offset += CHUNK_DAYS
+
+                    for trader in mkt_traders:
+                        retention_records.append({
+                            "market": mkt,
+                            "trader": trader,
+                            "window_days": win,
+                            "retained": trader in retained_set
+                        })
+        else:
+            logger.info("Skipping retention lookups as no new traders were found.")
+
+
+        if not retention_records:
+            logger.warning("No retention records generated. Summary will be empty or based on new traders only if any.")
+            # If new_traders is not empty, but retention_records is, means no one was retained.
+            # The aggregation logic below should handle this by creating 0s for retained counts/ratios.
+            # Initialize with expected columns if needed for robust aggregation, though pandas handles it.
+            retention = pd.DataFrame(columns=["market", "trader", "window_days", "retained"])
+        else:
+            retention = pd.DataFrame(retention_records)
+        
+        logger.info(f"Generated {len(retention)} retention records.")
+
+        # 3BB. Prepare lists of retained traders per market and window
+        if not retention.empty and 'retained' in retention.columns and 'trader' in retention.columns:
+            retained_traders_lists_df = retention[retention['retained'] == True].groupby(['market', 'window_days'])['trader'].apply(list).reset_index(name='retained_traders_list')
+        else:
+            retained_traders_lists_df = pd.DataFrame({
+                'market': pd.Series(dtype='str'), 
+                'window_days': pd.Series(dtype='int'), 
+                'retained_traders_list': pd.Series(dtype='object')
+            })
+
+
+        # 4. aggregate metrics
+        if retention.empty and new_traders.empty:
+            logger.info("Both new_traders and retention are empty. Returning empty summary.")
+            # Ensure all expected columns exist, even if with no data, matching Pydantic model
+            cols = ['market', 'new_traders', 'new_traders_list']
+            for win_days in RETENTION_WINDOWS_DAYS:
+                cols.append(f'retained_users_{win_days}d')
+                cols.append(f'retention_ratio_{win_days}d')
+                cols.append(f'retained_users_{win_days}d_list')
+            return pd.DataFrame(columns=cols)
+
+        summary_intermediate = pd.DataFrame()
+        if not retention.empty:
+            summary_intermediate = (
+                retention.groupby(["market", "window_days"])
+                         .agg(new_traders_count_in_group=("retained", "size"),
+                              retained_users_sum_in_group=("retained", "sum"))
+                         .reset_index()
+            )
+            if not summary_intermediate.empty: # Avoid division by zero if no groups or counts are zero
+                 summary_intermediate["retention_ratio_for_group"] = (
+                    summary_intermediate.retained_users_sum_in_group.astype(float) / 
+                    summary_intermediate.new_traders_count_in_group.astype(float)
+                ).round(3)
+            else: # Handle case where retention is not empty but groupby results in empty intermediate
+                summary_intermediate["retention_ratio_for_group"] = pd.Series(dtype=float)
+
+
+        # Initialize final_summary with total new traders per market from `new_traders` DataFrame
+        if not new_traders.empty:
+            final_summary_counts = new_traders.groupby('market').size().reset_index(name='new_traders')
+        else: # No new traders found at all
+            final_summary_counts = pd.DataFrame({'market': pd.Series(dtype='str'), 'new_traders': pd.Series(dtype='int')})
+
+        # Ensure all HYPE_MARKETS are present in final_summary, even if they had 0 new traders
+        all_market_names_df = pd.DataFrame({'market': list(HYPE_MARKETS.keys())})
+        final_summary = pd.merge(all_market_names_df, final_summary_counts, on='market', how='left').fillna({'new_traders': 0})
+        final_summary['new_traders'] = final_summary['new_traders'].astype(int)
+        
+        # Merge new traders lists
+        final_summary = pd.merge(final_summary, new_traders_lists_df, on='market', how='left')
+        # Ensure 'new_traders_list' column exists and fill NaNs with empty lists
+        if 'new_traders_list' not in final_summary.columns:
+            final_summary['new_traders_list'] = [[] for _ in range(len(final_summary))]
+        else:
+            final_summary['new_traders_list'] = final_summary['new_traders_list'].apply(lambda d: d if isinstance(d, list) else [])
+        
+        final_summary = final_summary.set_index('market')
+
+
+        for win_days in RETENTION_WINDOWS_DAYS:
+            retained_count_col = f'retained_users_{win_days}d'
+            retention_ratio_col = f'retention_ratio_{win_days}d'
+            retained_list_col = f'retained_users_{win_days}d_list'
+            
+            if not summary_intermediate.empty:
+                window_data = summary_intermediate[summary_intermediate.window_days == win_days]
+                if not window_data.empty:
+                    window_metrics = window_data[['market', 'retained_users_sum_in_group', 'retention_ratio_for_group']].set_index('market')
+                    window_metrics = window_metrics.rename(columns={
+                        'retained_users_sum_in_group': retained_count_col,
+                        'retention_ratio_for_group': retention_ratio_col
+                    })
+                    final_summary = final_summary.join(window_metrics)
+            
+            # Join retained traders lists for this window
+            if not retained_traders_lists_df.empty:
+                window_list_data = retained_traders_lists_df[retained_traders_lists_df.window_days == win_days]
+                if not window_list_data.empty:
+                    window_list_metrics = window_list_data[['market', 'retained_traders_list']].set_index('market')
+                    window_list_metrics = window_list_metrics.rename(columns={'retained_traders_list': retained_list_col})
+                    final_summary = final_summary.join(window_list_metrics)
+
+            # Fill NaN values for this window's columns (counts, ratios, and lists)
+            final_summary[retained_count_col] = final_summary.get(retained_count_col, pd.Series(0, index=final_summary.index)).fillna(0).astype(int)
+            final_summary[retention_ratio_col] = final_summary.get(retention_ratio_col, pd.Series(0.0, index=final_summary.index)).fillna(0.0).astype(float)
+            # For list columns, ensure they exist and NaNs are filled with empty lists
+            if retained_list_col not in final_summary.columns:
+                 final_summary[retained_list_col] = pd.Series([[] for _ in range(len(final_summary))], index=final_summary.index, dtype='object')
+            else:
+                final_summary[retained_list_col] = final_summary[retained_list_col].apply(lambda d: d if isinstance(d, list) else [])
+        
+        final_summary = final_summary.reset_index()
+        logger.info("Successfully generated retention summary.")
+        # logger.debug(f"Final Summary:\n{final_summary.to_string()}")
+        return final_summary
+
+    except Exception as e:
+        logger.error(f"Error in fetch_and_process_retention_data: {e}", exc_info=True)
+        # For Pydantic model compatibility, return DataFrame with expected columns in case of error
+        cols = ['market', 'new_traders', 'new_traders_list']
+        for w in RETENTION_WINDOWS_DAYS:
+            cols.extend([f'retained_users_{w}d', f'retention_ratio_{w}d', f'retained_users_{w}d_list'])
+        empty_df_on_error = pd.DataFrame(columns=cols)
+        
+        error_data = []
+        for market_name in HYPE_MARKETS.keys():
+            record: Dict[str, Any] = {'market': market_name, 'new_traders': 0, 'new_traders_list': []}
+            for w in RETENTION_WINDOWS_DAYS:
+                record[f'retained_users_{w}d'] = 0
+                record[f'retention_ratio_{w}d'] = 0.0
+                record[f'retained_users_{w}d_list'] = []
+            error_data.append(record)
+        if error_data:
+            empty_df_on_error = pd.DataFrame(error_data)
+        # Instead of returning, we raise HTTPException, so this df is for consistency if we changed to return it.
+        # However, the API will return based on the exception.
+        # For clarity, let's ensure the raised exception occurs rather than returning a df from here.
+        raise HTTPException(status_code=500, detail=f"Failed to fetch or process user retention data: {str(e)}")
+
+    finally:
+        if conn:
+            conn.close()
+            logger.info("Athena connection closed.")
+
+# ───────────────────────── 4. API Endpoint ───────────────────────── #
+
+@router.get("/summary", response_model=List[RetentionSummaryItem])
+async def get_user_retention_summary():
+    """
+    Provides a summary of user retention for "hype" markets.
+    - Identifies traders whose first order was in a hype market shortly after launch.
+    - Measures how many of those traders were active in *other* markets within 14 and 28 days.
+    """
+    try:
+        logger.info("Received request for /summary endpoint.")
+        summary_df = await fetch_and_process_retention_data()
+        
+        if summary_df.empty and not HYPE_MARKETS: # No markets configured
+             return []
+        if summary_df.empty and HYPE_MARKETS: # Markets configured but no data (e.g. no new users at all)
+            # Construct a list of RetentionSummaryItem with 0 values for all configured markets
+            # This ensures the frontend gets a consistent structure.
+            results = []
+            for market_name in HYPE_MARKETS.keys():
+                item_data: Dict[str, Any] = {"market": market_name, "new_traders": 0, "new_traders_list": []}
+                for win_day in RETENTION_WINDOWS_DAYS:
+                    item_data[f"retained_users_{win_day}d"] = 0
+                    item_data[f"retention_ratio_{win_day}d"] = 0.0
+                    item_data[f"retained_users_{win_day}d_list"] = []
+                results.append(RetentionSummaryItem(**item_data))
+            return results
+
+        # Convert DataFrame to list of dicts for Pydantic model validation
+        results_dict = summary_df.to_dict(orient='records')
+        
+        # Validate with Pydantic model
+        validated_results = [RetentionSummaryItem(**item) for item in results_dict]
+        logger.info(f"Successfully processed request for /summary. Returning {len(validated_results)} summary items.")
+        return validated_results
+    except HTTPException as http_exc:
+        # Re-raise HTTPExceptions directly
+        raise http_exc
+    except Exception as e:
+        logger.error(f"Unhandled error in /summary endpoint: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="An internal server error occurred.")
+
+# To run this API locally (example):
+# Ensure FastAPI and Uvicorn are installed: pip install fastapi uvicorn
+# Save this file as user_retention_api.py
+# Run with: uvicorn user_retention_api:router --reload --port 8001 (assuming this router is added to a FastAPI app)

--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,7 @@ from backend.api import (
     ucache,
     vaults,
     high_leverage_api,
+    user_retention_api,
 )
 from backend.middleware.cache_middleware import CacheMiddleware
 from backend.middleware.readiness import ReadinessMiddleware
@@ -92,6 +93,7 @@ app.include_router(positions.router, prefix="/api/positions", tags=["positions"]
 app.include_router(market_recommender_api.router, prefix="/api/market-recommender", tags=["market-recommender"])
 app.include_router(open_interest_api.router, prefix="/api/open-interest", tags=["open-interest"])
 app.include_router(high_leverage_api.router, prefix="/api/high-leverage", tags=["high-leverage"])
+app.include_router(user_retention_api.router, prefix="/api/user-retention", tags=["user-retention"])
 # NOTE: All other routes should be in /api/* within the /api folder. Routes outside of /api are not exposed in k8s
 @app.get("/")
 async def root():

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from page.welcome import welcome_page
 from page.market_recommender_page import market_recommender_page
 from page.open_interest_page import open_interest_page
 from page.high_leverage_page import high_leverage_page
+from page.user_retention_page import user_retention_page
 
 load_dotenv()
 
@@ -148,6 +149,12 @@ if __name__ == "__main__":
             url_path="high-leverage",
             title="High Leverage",
             icon="⚡",
+        ),
+        st.Page(
+            needs_backend(user_retention_page),
+            url_path="user-retention",
+            title="User Retention",
+            icon="👥",
         ),
     ]
 

--- a/src/page/user_retention_page.py
+++ b/src/page/user_retention_page.py
@@ -1,0 +1,227 @@
+# This page will display the user retention data in a table format.
+# It will receive the data from the user_retention endpoint from the backend
+# It will also allow the user to filter the data by market and date range.
+# It will also allow the user to download the data in a CSV format.
+# It will also allow the user to export the data to a JSON file.
+
+import streamlit as st
+import pandas as pd
+import json # For JSON export
+import time # For potential retry delays
+from lib.api import fetch_api_data # Assuming this is your helper for API calls
+
+RETRY_DELAY_SECONDS = 5 # For retrying if API is processing
+
+# Helper function to check if the API result indicates backend processing
+def is_processing(result):
+    return isinstance(result, dict) and result.get("result") == "processing"
+
+# Helper function to check for errors in API result
+def has_error(result):
+    if result is None:
+        return True
+    if isinstance(result, dict):
+        # Check for a specific error structure if your API has one
+        # For example, if errors are always like {"detail": "error message"}
+        if "detail" in result and isinstance(result["detail"], str):
+            return True 
+        # Or a more generic check if your API returns a specific error key or status
+        if result.get("result") == "error" or result.get("status") == "error":
+            return True
+    return False
+
+# Helper to get error message
+def get_error_message(result):
+    if isinstance(result, dict) and "detail" in result:
+        return str(result["detail"])
+    if isinstance(result, dict) and "message" in result:
+        return str(result["message"])
+    return "Could not connect or fetch data from the backend."
+
+@st.cache_data(ttl=300) # Cache data for 5 minutes
+def load_retention_data():
+    """Fetches user retention summary data from the backend API."""
+    # Adjust 'section' and 'path' according to your fetch_api_data implementation
+    # and how the user_retention_api.router is mounted in your FastAPI app.
+    # Assuming the new endpoint is mounted under a 'user-retention' section similar to 'high-leverage'
+    data = fetch_api_data(section="user-retention", path="summary", retry=False)
+    return data
+
+def user_retention_page():
+    st.title("User Retention Analysis for Hype Markets")
+
+    st.markdown("""
+    This page displays user retention data for specified "hype" markets. 
+    It shows how many new traders (first-ever order in the market within 7 days of launch) 
+    were retained by trading in *any other* market within 14 and 28 days.
+    """)
+
+    # Initial data load
+    data = load_retention_data()
+
+    # Handle processing state from API (if applicable)
+    if is_processing(data):
+        st.info(f"Backend is processing user retention data. Auto-refreshing in {RETRY_DELAY_SECONDS} seconds...")
+        with st.spinner("Please wait..."):
+            time.sleep(RETRY_DELAY_SECONDS)
+        st.rerun()
+        return
+
+    # Handle errors from API
+    if has_error(data):
+        error_msg = get_error_message(data)
+        st.error(f"Failed to fetch user retention data: {error_msg}")
+        if st.button("Retry Data Load"):
+            st.cache_data.clear() # Clear cache before retrying
+            st.rerun()
+        return
+    
+    # If data is a list (expected for summary items)
+    if isinstance(data, list) and data:
+        try:
+            df = pd.DataFrame(data)
+
+            # Ensure correct data types, especially for numeric columns that might be None
+            df['new_traders'] = pd.to_numeric(df['new_traders'], errors='coerce').fillna(0).astype(int)
+            df['retained_users_14d'] = pd.to_numeric(df['retained_users_14d'], errors='coerce').fillna(0).astype(int)
+            df['retention_ratio_14d'] = pd.to_numeric(df['retention_ratio_14d'], errors='coerce').fillna(0.0).astype(float)
+            df['retained_users_28d'] = pd.to_numeric(df['retained_users_28d'], errors='coerce').fillna(0).astype(int)
+            df['retention_ratio_28d'] = pd.to_numeric(df['retention_ratio_28d'], errors='coerce').fillna(0.0).astype(float)
+
+            # Ensure list columns are treated as objects and handle potential NaNs (e.g. if API returns null instead of [])
+            list_columns = ['new_traders_list', 'retained_users_14d_list', 'retained_users_28d_list']
+            for col in list_columns:
+                if col in df.columns:
+                    df[col] = df[col].apply(lambda x: x if isinstance(x, list) else [])
+                else: # If a list column is missing from API response for some reason
+                    df[col] = pd.Series([[] for _ in range(len(df))], dtype='object')
+
+            # Rename columns for better display
+            df.rename(columns={
+                'market': 'Market',
+                'new_traders': 'New Traders (Count)',
+                'retained_users_14d': 'Retained at 14d (Count)',
+                'retention_ratio_14d': 'Retention Rate 14d',
+                'retained_users_28d': 'Retained at 28d (Count)',
+                'retention_ratio_28d': 'Retention Rate 28d',
+                'new_traders_list': 'New Traders (List)',
+                'retained_users_14d_list': 'Retained 14d (List)',
+                'retained_users_28d_list': 'Retained 28d (List)'
+            }, inplace=True)
+            
+            # --- Filtering (Applied to the original comprehensive df) ---
+            st.sidebar.header("Filters")
+            all_markets = ["All"] + sorted(df["Market"].unique().tolist())
+            selected_market = st.sidebar.selectbox("Filter by Market", all_markets)
+
+            filtered_df = df.copy()
+            if selected_market != "All":
+                filtered_df = filtered_df[filtered_df["Market"] == selected_market]
+            
+            # (Optional: Date range filter if your data/API supports it. Not implemented based on current API)
+            # selected_date_range = st.sidebar.date_input("Filter by Date Range (if applicable)", [])
+            # if selected_date_range and len(selected_date_range) == 2:
+            #     start_date, end_date = selected_date_range
+            #     # Add logic to filter df by date if a date column exists
+            #     pass 
+
+            # --- Display Tables ---
+            if filtered_df.empty:
+                st.info("No data available for the selected filters.")
+            else:
+                # Table 1: Main Summary
+                st.subheader("Overall Retention Summary")
+                summary_cols = [
+                    'Market',
+                    'New Traders (Count)',
+                    'Retained at 14d (Count)',
+                    'Retention Rate 14d',
+                    'Retained at 28d (Count)',
+                    'Retention Rate 28d'
+                ]
+                main_summary_df = filtered_df[summary_cols]
+                st.dataframe(
+                    main_summary_df.style.format({
+                        'Retention Rate 14d': '{:.2%}',
+                        'Retention Rate 28d': '{:.2%}'
+                    }), 
+                    hide_index=True, 
+                    use_container_width=True
+                )
+
+                # Table 2: New Traders List
+                st.subheader("New Traders Lists")
+                new_traders_list_df = filtered_df[['Market', 'New Traders (List)']]
+                # Filter out rows where the list is empty to make the table cleaner
+                new_traders_list_df = new_traders_list_df[new_traders_list_df['New Traders (List)'].apply(lambda x: len(x) > 0)]
+                if not new_traders_list_df.empty:
+                    st.dataframe(new_traders_list_df, hide_index=True, use_container_width=True)
+                else:
+                    st.caption("No new traders found for the selected market(s) or new trader lists are empty.")
+
+                # Table 3: 14-Day Retained Users List
+                st.subheader("14-Day Retained User Lists")
+                retained_14d_list_df = filtered_df[['Market', 'Retained 14d (List)']]
+                retained_14d_list_df = retained_14d_list_df[retained_14d_list_df['Retained 14d (List)'].apply(lambda x: len(x) > 0)]
+                if not retained_14d_list_df.empty:
+                    st.dataframe(retained_14d_list_df, hide_index=True, use_container_width=True)
+                else:
+                    st.caption("No users retained at 14 days for the selected market(s) or lists are empty.")
+
+                # Table 4: 28-Day Retained Users List
+                st.subheader("28-Day Retained User Lists")
+                retained_28d_list_df = filtered_df[['Market', 'Retained 28d (List)']]
+                retained_28d_list_df = retained_28d_list_df[retained_28d_list_df['Retained 28d (List)'].apply(lambda x: len(x) > 0)]
+                if not retained_28d_list_df.empty:
+                    st.dataframe(retained_28d_list_df, hide_index=True, use_container_width=True)
+                else:
+                    st.caption("No users retained at 28 days for the selected market(s) or lists are empty.")
+
+                # --- Data Export (based on the main summary table) --- 
+                st.subheader("Export Main Summary Data")
+                col1, col2 = st.columns(2)
+
+                # CSV Download
+                csv_data = main_summary_df.to_csv(index=False).encode('utf-8')
+                col1.download_button(
+                    label="Download Summary as CSV",
+                    data=csv_data,
+                    file_name="user_retention_main_summary.csv",
+                    mime="text/csv",
+                )
+
+                # JSON Export/Display
+                json_data_str = main_summary_df.to_json(orient="records", indent=4)
+                col2.download_button(
+                    label="Download Summary as JSON",
+                    data=json_data_str,
+                    file_name="user_retention_main_summary.json",
+                    mime="application/json",
+                )
+                with st.expander("View Main Summary JSON Data"):
+                    st.json(json_data_str)
+        
+        except Exception as e:
+            st.error(f"An error occurred while processing and displaying the data: {e}")
+            import traceback
+            st.text(traceback.format_exc())
+
+    elif isinstance(data, list) and not data: # API returned empty list
+        st.info("No user retention data found. The backend returned an empty list. This might mean no hype markets are configured or no new traders were found for any configured market.")
+        if st.button("Reload Data"):
+            st.cache_data.clear()
+            st.rerun()
+
+    else: # Unexpected data format
+        st.error("Received unexpected data format from the backend.")
+        st.write("Data received:", data)
+        if st.button("Attempt Reload"):
+            st.cache_data.clear()
+            st.rerun()
+
+    if st.button("Refresh Data"):
+        st.cache_data.clear()
+        st.rerun()
+
+if __name__ == "__main__":
+    user_retention_page()


### PR DESCRIPTION
- Introduced a new User Retention API by adding the `user_retention_api` router in the backend application, making it accessible at the `/api/user-retention` endpoint.
- Developed a corresponding Streamlit page for user retention analysis, allowing users to view and filter retention data for hype markets.
- Implemented data fetching from the new API, including features for displaying retention metrics, new trader counts, and lists of retained users.
- Provide options to download data in CSV and JSON formats, along with clear error handling and processing states.