### PR TITLE
Update Solana dependency in requirements.txt from version 0.36.1 to 0.36.6 to resolve deployment issues in kubernetes prod.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy==1.26.4
 pandas==2.2.3
 python-dotenv==1.0.1
 pydantic==2.10.6
-solana==0.36.1
+solana==0.36.6
 streamlit==1.42.1
 uvicorn==0.34.0
 requests==2.32.3


### PR DESCRIPTION
```
#9 19.08 ERROR: Cannot install -r requirements.txt (line 15) and -r requirements.txt (line 9) because these package versions have conflicting dependencies.
#9 19.08
#9 19.08 The conflict is caused by:
#9 19.08     solana 0.36.1 depends on websockets<=12.0 and >=9.0
#9 19.08     driftpy 0.8.56 depends on websockets==13.0
#9 19.08
```