### PR TITLE
Goldhaxx/DATA-73/add-filter-for-each-isolated-pool-on-price-shock-page

### DIFF
--- a/backend/utils/user_metrics.py
+++ b/backend/utils/user_metrics.py
@@ -308,8 +308,8 @@ def get_user_leverages_for_price_shock(
         new_oracles_dat_down.append({})
 
     distorted_oracles = []
-    cache_up = copy.deepcopy(drift_client.account_subscriber.cache)
-    cache_down = copy.deepcopy(drift_client.account_subscriber.cache)
+    cache_up = copy.copy(drift_client.account_subscriber.cache)
+    cache_down = copy.copy(drift_client.account_subscriber.cache)
 
     for key, val in drift_client.account_subscriber.cache["oracle_price_data"].items():
         for i in range(scenarios):


### PR DESCRIPTION
fixed issues with ucache generation and responsiveness/state race conditions on price-shock page

- Introduced a new helper function `initialize_widget_state` to manage session state for widgets based on query parameters, improving user experience by maintaining selections across page loads.
- Updated asset group, scenarios, and pool ID selections to utilize session state, ensuring that user interactions persist correctly.
- Enhanced the display of selected pool ID in the information message, providing clearer context for users regarding the data being displayed.
- Refactored API parameter preparation to directly use values from session state, streamlining the data flow and improving code clarity.